### PR TITLE
Week 2: Integrate libpqxx Library for PostgreSQL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,24 @@
+cmake_minimum_required(VERSION 3.10)
+
+project(StudentInfoSystem VERSION 1.0 LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+if(MSVC)
+    add_compile_options(/W3 /WX)
+else()
+    add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+include_directories(include)
+
+# PostgreSQL Kutuphanesini Bul (Docker ortaminda calisacak)
+find_package(libpqxx REQUIRED)
+
+file(GLOB SOURCES "src/*.cpp")
+
+add_executable(StudentInfoSystem ${SOURCES})
+
+# Kutuphaneyi projeye bagla
+target_link_libraries(StudentInfoSystem PRIVATE libpqxx::pqxx)


### PR DESCRIPTION
Added PostgreSQL connection library (libpqxx) dependency.

Changes:
- Updated CMakeLists.txt to find and link `libpqxx`.
- Updated main.cpp to include the library header and verify installation.

Note: Local build may fail on Windows if libpqxx is not installed. This is intended for the Docker environment.

Closes #8